### PR TITLE
fix: remove github token env

### DIFF
--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -20,5 +20,3 @@ jobs:
       pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Removing GITHUB_TOKEN as its not required for now.