### PR TITLE
fix: remove github token env from workflow call

### DIFF
--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -2,10 +2,6 @@ name: "PR-Validator"
 
 on:
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        description: 'GitHub token to authenticate API requests'
-        required: true
   pull_request_target:
     types:
       - opened
@@ -20,3 +16,5 @@ jobs:
       pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Removing github token from workflow_call.